### PR TITLE
Fix not found URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A podcast listening PWA
 
+Check out the live preview at [cast-iu.pages.dev](https://cast-iu.pages.dev)
+
 ## Working with the source
 
 To install the packages:

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,4 @@
 <script context="module" lang="ts">
-  import AudioControls from 'src/features/audio-controls.svelte';
-
   export const prerender = true;
 </script>
 
@@ -21,8 +19,6 @@
   <span class="material-icons-round"> favorite_border </span>
 
   <h1 class="text-3xl font-bold underline text-yellow-400">Hello world!</h1>
-
-  <AudioControls />
 </section>
 
 <style>


### PR DESCRIPTION
Simply removes the offending component from the rendering (until it is properly replaced with something useful).
Also adds the site link to the README.
Hopefully fixes #38 