### PR TITLE
Fix VanishMax's name case in reviewer lottery

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -4,7 +4,7 @@ groups:
     internal_reviewers: 1 # how many reviewers do you want to assign when the PR author belongs to this group?
     usernames: # github usernames of the reviewers
       - illright
-      - vanishmax
+      - VanishMax
       - aabounegm
       - alkaitagi
       - khaledismaeel


### PR DESCRIPTION
I also checked the other usernames but they all seem to be correct.
Closes #62