### PR TITLE
Remove the unnecessary fields and add the schema

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,8 +1,6 @@
 {
+  "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://localhost:3000/",
-  "componentFolder": "src",
-  "testFiles": "**/*spec.{js,ts}",
-  "supportFile": "cypress/support/index.ts",
   "pluginsFile": false,
   "viewportHeight": 720,
   "viewportWidth": 360


### PR DESCRIPTION
Component folder and test files are only applicable to Cypress Component Testing, and that doesn't support Svelte as of now