### PR TITLE
Try setting up the hero animation and fail

### DIFF
--- a/src/lib/entities/podcast/ui/podcast-display.svelte
+++ b/src/lib/entities/podcast/ui/podcast-display.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { H1, s } from '$lib/shared/ui';
   import type { Podcast } from '$lib/shared/api';
+  import { send, receive } from '$lib/shared/ui/animation';
 
   export let podcast: Podcast;
 </script>
 
 <div class="flex flex-row gap-4 p-2">
-  <img class="w-24 h-24 rounded-xl" src={podcast.coverUrl} alt="" />
+  <img
+    class="w-24 h-24 rounded-xl"
+    src={podcast.coverUrl}
+    alt=""
+    in:receive={{ key: podcast.id }}
+    out:send={{ key: podcast.id }}
+  />
+
   <div class="flex flex-col gap-1 text-xs pt-2">
     <H1>{podcast.title}</H1>
     <p>{podcast.author}</p>

--- a/src/lib/entities/podcast/ui/podcast-tile.svelte
+++ b/src/lib/entities/podcast/ui/podcast-tile.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import cx from 'clsx';
   import type { Podcast } from '$lib/shared/api';
+  import { send, receive } from '$lib/shared/ui/animation';
 
   let _class = '';
   export { _class as class };
@@ -12,7 +13,15 @@
   class={cx('grid', 'gap-x-4', 'text-slate-100', _class, large && 'large p-2')}
   href="/podcasts/{podcast.id}"
 >
-  <img class="rounded-lg aspect-square" class:row-span-2={!large} src={podcast.coverUrl} alt="" />
+  <img
+    class="rounded-lg aspect-square"
+    class:row-span-2={!large}
+    src={podcast.coverUrl}
+    alt=""
+    in:receive={{ key: podcast.id }}
+    out:send={{ key: podcast.id }}
+  />
+
   <span class="author font-lato text-xs" class:mt-1={large}>
     {podcast.author}
   </span>

--- a/src/lib/shared/ui/animation/hero.ts
+++ b/src/lib/shared/ui/animation/hero.ts
@@ -1,0 +1,6 @@
+import { crossfade } from 'svelte/transition';
+
+export const [send, receive] = crossfade({
+  // duration: 300,
+  // delay: 350,
+});

--- a/src/lib/shared/ui/animation/index.ts
+++ b/src/lib/shared/ui/animation/index.ts
@@ -1,0 +1,1 @@
+export { send, receive } from './hero';

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,6 +6,7 @@
   import { trackAuthStatus } from '$lib/features/authenticate';
   import { src, duration, currentTime, paused, playbackRate, buffered } from '$lib/entities/audio';
   import '$lib/app.css';
+  import { page } from '$app/stores';
 
   // Svelte can't handle its own type conversion with TypeScript
   const bufferedNative = buffered as unknown as Writable<TimeRanges>;
@@ -13,17 +14,31 @@
   onMount(trackAuthStatus);
 </script>
 
-<audio
-  src={$src}
-  bind:duration={$duration}
-  bind:currentTime={$currentTime}
-  bind:paused={$paused}
-  bind:playbackRate={$playbackRate}
-  bind:buffered={$bufferedNative}
-/>
-<main class="relative margin-auto h-full w-full max-w-md bg-slate-800 text-white">
-  <slot />
-  <BottomBar />
-</main>
+{#key $page}
+  <div class="layout relative min-h-screen w-full">
+    <audio
+      src={$src}
+      bind:duration={$duration}
+      bind:currentTime={$currentTime}
+      bind:paused={$paused}
+      bind:playbackRate={$playbackRate}
+      bind:buffered={$bufferedNative}
+    />
+    <main class="relative mx-auto h-full w-full max-w-md bg-slate-800 text-white">
+      <slot />
+      <BottomBar />
+    </main>
 
-<SnackbarQueue />
+    <SnackbarQueue />
+  </div>
+{/key}
+
+<style>
+  :global(#svelte) {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: flex-end;
+    height: 100vh;
+    overflow-y: hidden;
+  }
+</style>


### PR DESCRIPTION
It will never close #133 

Well, It was supposed to be easy in Svelte... But not in SvelteKit. The problem is that for the `crossfade` function (the only solution suitable for hero images) all contents of `_layout.svelte` is recreated next to the previous layout. You can try clonning this PR, tap on a podcast link and notice animation working. But check devtools: the are two `.layout`. The more you walk through the app, the more layouts you'll see. Somehow, after animation finished, it doesn't get removed. Believe me, I've tried a lot. 

Referencing everything I tried:
* [Dev.to article](https://dev.to/giorgosk/smooth-page-transitions-in-layout-svelte-with-sveltekit-or-sapper-4mm1). Inside of it, the author states _"Perhaps if anyone know how to add crossfade to it please do let me know in the comments"_.
* [Svelte REPL, showing `crossfade` function usage](https://svelte.dev/repl/0ad58a0d830f4001b91409e40164aa24?version=3.44.1)
* [StackOverflow answer](https://stackoverflow.com/questions/69896477/svelte-page-transition-duplicating-entire-site-layout-svelte) about the `crossfade` problem that no one knows how to fix without introducing new bugs