### PR TITLE
Fix env var names

### DIFF
--- a/src/lib/shared/api/credentials.ts
+++ b/src/lib/shared/api/credentials.ts
@@ -4,6 +4,6 @@
  * VITE_SUPABASE_KEY – Private key to Supabase connection with the API
  */
 export default {
-  SUPABASE_URL: (import.meta.env.VITE_SUPABASE_URL as string) || '',
-  SUPABASE_USER_KEY: (import.meta.env.VITE_SUPABASE_KEY as string) || '',
+  VITE_SUPABASE_APP_URL: (import.meta.env.VITE_SUPABASE_APP_URL as string) || '',
+  VITE_SUPABASE_PUBLIC_ANON_KEY: (import.meta.env.VITE_SUPABASE_PUBLIC_ANON_KEY as string) || '',
 };

--- a/src/lib/shared/api/supabase.ts
+++ b/src/lib/shared/api/supabase.ts
@@ -1,8 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 import constants from './credentials';
 
-const supabaseClient = createClient(constants.SUPABASE_URL, constants.SUPABASE_USER_KEY, {
-  fetch: fetch.bind(globalThis),
-});
+const supabaseClient = createClient(
+  constants.VITE_SUPABASE_APP_URL,
+  constants.VITE_SUPABASE_PUBLIC_ANON_KEY,
+  {
+    fetch: fetch.bind(globalThis),
+  }
+);
 
 export default supabaseClient;


### PR DESCRIPTION
Apparently, we broke `supabaseClient` by renaming the env vars in #146; now running the server locally `supabaseClient` is `undefined`. This should fix it.