### PR TITLE
Fix play button icon

### DIFF
--- a/src/lib/features/playback-controls/model/toggle-global-playback.ts
+++ b/src/lib/features/playback-controls/model/toggle-global-playback.ts
@@ -1,8 +1,9 @@
 import { get } from 'svelte/store';
 import { play, pause, paused } from '$lib/entities/audio';
+import { currentlyPlayingEpisode } from '$lib/entities/episode';
 
 export function toggleGlobalPlayback(src?: string) {
-  if (get(paused)) {
+  if (get(paused) || (src !== get(currentlyPlayingEpisode)?.audioUrl && src !== undefined)) {
     play(src);
   } else {
     pause();

--- a/src/lib/widgets/episode/ui/episode-card.svelte
+++ b/src/lib/widgets/episode/ui/episode-card.svelte
@@ -17,7 +17,10 @@
 
 <EpisodeCardShell {episode}>
   <svelte:fragment slot="play">
-    <PlaybackButton playing={!$paused} on:click={togglePlaying} />
+    <PlaybackButton
+      playing={!$paused && $currentlyPlayingEpisode === episode}
+      on:click={togglePlaying}
+    />
   </svelte:fragment>
 
   <svelte:fragment slot="download">

--- a/src/lib/widgets/episode/ui/episode-card.svelte
+++ b/src/lib/widgets/episode/ui/episode-card.svelte
@@ -10,8 +10,8 @@
   export let episode: Episode;
 
   const togglePlaying = () => {
-    currentlyPlayingEpisode.set(episode);
     toggleGlobalPlayback(episode.audioUrl);
+    currentlyPlayingEpisode.set(episode);
   };
 </script>
 


### PR DESCRIPTION
Resolves #153 

# Known issues

Playing another episode while one is already playing switches the current episode correctly, and leaves `paused` as `false` also correctly, but for some reason the audio element itself stops playing.