### PR TITLE
Remove the code that was pausing playback while scrubbing

### DIFF
--- a/src/lib/features/playback-controls/ui/scrubbing-bar.svelte
+++ b/src/lib/features/playback-controls/ui/scrubbing-bar.svelte
@@ -12,7 +12,7 @@
   $: remaining = duration - position;
 
   interface ScrubbingBarEvents {
-    scrub: { dragging: boolean; position: number };
+    scrub: number;
   }
 
   const dispatch = createEventDispatcher<ScrubbingBarEvents>();
@@ -26,9 +26,7 @@
     step={0.001}
     value={position}
     aria-valuetext={formatDuration(position)}
-    on:pointerup={() => dispatch('scrub', { dragging: false, position })}
-    on:input={(e) =>
-      dispatch('scrub', { dragging: true, position: parseInt(e.currentTarget.value) })}
+    on:input={(e) => dispatch('scrub', parseInt(e.currentTarget.value))}
     class="scrubbing-bar slider-progress w-full"
     style:--value={position}
     style:--min={0}

--- a/src/lib/widgets/now-playing/ui/now-playing.svelte
+++ b/src/lib/widgets/now-playing/ui/now-playing.svelte
@@ -74,11 +74,7 @@
         duration={$duration}
         position={$currentTime}
         buffered={$buffered}
-        on:scrub={(e) => {
-          if (e.detail.dragging) pause();
-          else play();
-          seek(e.detail.position);
-        }}
+        on:scrub={(e) => seek(e.detail)}
       />
       <div class="w-full mt-4 flex items-center justify-between">
         <button


### PR DESCRIPTION
Closes #231 

We previously wrote some code that would pause the playback while dragging the scrubbing bar, but turns out it's a problem for Firefox who dispatches yet another `input` event after the `pointerup` event, which is what was causing the pause.

I tried all sorts of solutions, all sorts of state tracking, some of that would fix the issue but introduce a worse one in one of the browsers. This behaviour seems to be the most stable and harmless. Moreover, Firefox doesn't play while you scrub, only Chrome does, but it's not a problem either way